### PR TITLE
fix incorrect permission of generated report file

### DIFF
--- a/tool/webshell-detector/bin/detector.go
+++ b/tool/webshell-detector/bin/detector.go
@@ -129,7 +129,7 @@ func printResult(fileIndex int, filePath string, fileRisk int) {
 		res = fmt.Sprintf("[+] %08d %-80s Risk:%d\n", fileIndex, filePath, fileRisk)
 	}
 	if *outputPtr != "" {
-		outputFile, err := os.OpenFile(*outputPtr, os.O_WRONLY|os.O_APPEND, os.ModePerm)
+		outputFile, err := os.OpenFile(*outputPtr, os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -181,7 +181,7 @@ func main() {
 		log.Println("Detector kernel cannot load.")
 	}
 	if *outputPtr != "" {
-		outputFile, err := os.OpenFile(*outputPtr, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, os.ModePerm)
+		outputFile, err := os.OpenFile(*outputPtr, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -288,7 +288,7 @@ func main() {
 			outputFile.Close()
 		}
 		work(files)
-		outputFile, err = os.OpenFile(*outputPtr, os.O_WRONLY|os.O_APPEND, os.ModePerm)
+		outputFile, err = os.OpenFile(*outputPtr, os.O_WRONLY|os.O_APPEND, 0600)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/tool/webshell-detector/src/genOpSerialData_test.go
+++ b/tool/webshell-detector/src/genOpSerialData_test.go
@@ -50,5 +50,5 @@ package WebshellDetector
 // 	isWebshellO = 1
 // 	filepath.Walk("../sample/predict/webshell", walkFunc_genOpSerialData)
 
-// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/opSerialData.txt", []byte(resultO.String()), os.ModePerm)
+// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/opSerialData.txt", []byte(resultO.String()), 0600)
 // }

--- a/tool/webshell-detector/src/genProcessorData_test.go
+++ b/tool/webshell-detector/src/genProcessorData_test.go
@@ -50,5 +50,5 @@ package WebshellDetector
 // 	isWebshellP = 1
 // 	filepath.Walk("../sample/predict/webshell", walkFunc_genProcessorData)
 
-// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/processorData.txt", []byte(resultP.String()), os.ModePerm)
+// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/processorData.txt", []byte(resultP.String()), 0600)
 // }

--- a/tool/webshell-detector/src/genWordsData_test.go
+++ b/tool/webshell-detector/src/genWordsData_test.go
@@ -52,5 +52,5 @@ package WebshellDetector
 // 		return
 // 	}
 
-// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/wordsData.txt", data, os.ModePerm)
+// 	ioutil.WriteFile("../tools/cross-validation tool/MetaData/wordsData.txt", data, 0600)
 // }


### PR DESCRIPTION
os.ModePerm is only intended to be used as a bitmask
choose 0600 since the report file may contain sensitive information

fix #1