### PR TITLE
Fix single file test counter

### DIFF
--- a/tool/webshell-detector/bin/detector.go
+++ b/tool/webshell-detector/bin/detector.go
@@ -87,6 +87,9 @@ func multiTest(detectPath string) {
 }
 
 func singleTest(path string) {
+
+	countFile++
+	
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Fix bug of cannot count single file test in `bin/detector.go`