### PR TITLE
optimization statWords

### DIFF
--- a/tool/webshell-detector/src/Stat.go
+++ b/tool/webshell-detector/src/Stat.go
@@ -85,16 +85,21 @@ func lineVariationCoefficient(src string) float64 {
 }
 
 func statWords(src string) []int64 {
-	// get all words
-	wordReg, _ := regexp.Compile(`[a-zA-Z0-9]*`)
 	var result []int64
-	regRusult := wordReg.FindAllStringIndex(src, -1)
-	for _, index := range regRusult {
-		if index[1]-index[0] > 0 {
-			result = append(result, int64(index[1]-index[0]))
-
+	l := int64(0)
+	for _, c := range src {
+		if (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122) {
+			l++
+		} else if l != 0 {
+			result = append(result, l)
+			l = 0
 		}
 	}
+
+	if l != 0 {
+		result = append(result, l)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
分析程序 allocs 后发现，原 statWords 函数使用正则匹配，消耗大量内存和 GC 资源，改用 ascii 码判断可明显提升效率。

![1](https://user-images.githubusercontent.com/30936981/135015686-e3ea90a5-35af-4c3b-b867-6a292682b349.png)

如下为新旧函数在处理相同文本情况下的性能对比，statWords2 为修改后方法：

![2](https://user-images.githubusercontent.com/30936981/135037847-0a8fb261-012b-47b9-8afc-5b89489c96f1.png)

**函数已做测试，用例输出结果皆一致**

